### PR TITLE
Fix Issue #1262: Capitalize subfields in tags list

### DIFF
--- a/examples/di/arxiv_reader.py
+++ b/examples/di/arxiv_reader.py
@@ -5,7 +5,7 @@ from metagpt.roles.di.data_interpreter import DataInterpreter
 
 async def main():
     template = "https://arxiv.org/list/{tag}/pastweek?skip=0&show=300"
-    tags = ["cs.ai", "cs.cl", "cs.lg", "cs.se"]
+    tags = ["cs.AI", "cs.CL", "cs.LG", "cs.SE"]
     urls = [template.format(tag=tag) for tag in tags]
     prompt = f"""This is a collection of arxiv urls: '{urls}' .
 Record each article, remove duplicates by title (they may have multiple tags), filter out papers related to 


### PR DESCRIPTION
This pull request addresses issue #1262 by capitalizing the subfields in the tags list in the arxiv_reader.py file.