### PR TITLE
Fix: Update unpacking logic to handle 13 values instead of 11 in _get_protocol_params

### DIFF
--- a/metagpt/provider/dashscope_api.py
+++ b/metagpt/provider/dashscope_api.py
@@ -48,6 +48,8 @@ def build_api_arequest(
         request_timeout,
         form,
         resources,
+        additional_param1,
+        additional_param2,
     ) = _get_protocol_params(kwargs)
     task_id = kwargs.pop("task_id", None)
     if api_protocol in [ApiProtocol.HTTP, ApiProtocol.HTTPS]:


### PR DESCRIPTION
This pull request addresses the issue by updating the unpacking logic in the `dashscope_api.py` file to handle 13 values instead of 11.