### PR TITLE
Fix Issue #1367: Update unpacking logic to handle 13 values returned by _get_protocol_params

### DIFF
--- a/metagpt/provider/dashscope_api.py
+++ b/metagpt/provider/dashscope_api.py
@@ -48,6 +48,8 @@ def build_api_arequest(
         request_timeout,
         form,
         resources,
+        base_address,
+        flattened_output
     ) = _get_protocol_params(kwargs)
     task_id = kwargs.pop("task_id", None)
     if api_protocol in [ApiProtocol.HTTP, ApiProtocol.HTTPS]:


### PR DESCRIPTION
This pull request addresses issue #1367 by updating the unpacking logic in `metagpt/provider/dashscope_api.py` to handle 13 values returned by `_get_protocol_params`.