### PR TITLE
Fix Issue #1379: Added None check for code_plan_and_change_doc to prevent AttributeError

### DIFF
--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -118,7 +118,7 @@ class Engineer(Role):
 
             dependencies = {coding_context.design_doc.root_relative_path, coding_context.task_doc.root_relative_path}
             if self.config.inc:
-                dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+            if coding_context.code_plan_and_change_doc is not None:
             await self.project_repo.srcs.save(
                 filename=coding_context.filename,
                 dependencies=list(dependencies),


### PR DESCRIPTION
This pull request addresses issue #1379 by adding a check to ensure that coding_context.code_plan_and_change_doc is not None before accessing its root_relative_path attribute.