### PR TITLE
Fix None check for coding_context.code_plan_and_change_doc

### DIFF
--- a/metagpt/roles/engineer.py
+++ b/metagpt/roles/engineer.py
@@ -118,7 +118,13 @@ class Engineer(Role):
 
             dependencies = {coding_context.design_doc.root_relative_path, coding_context.task_doc.root_relative_path}
             if self.config.inc:
-                dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                if coding_context.code_plan_and_change_doc is not None:
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
+                    dependencies.add(coding_context.code_plan_and_change_doc.root_relative_path)
             await self.project_repo.srcs.save(
                 filename=coding_context.filename,
                 dependencies=list(dependencies),


### PR DESCRIPTION
This pull request adds a None check for coding_context.code_plan_and_change_doc to prevent potential errors.